### PR TITLE
Push doesn't collect all objects if multiple blobs use the same hash

### DIFF
--- a/packages/push-mixin/ts/index.ts
+++ b/packages/push-mixin/ts/index.ts
@@ -36,7 +36,7 @@ export default function pushMixin<T extends Constructor<IObjectRepo & IWalkersRe
         await this.addToMap(hash, localObjects);
         if(await this.addToMap(commit.body.tree, localObjects)) continue;
         for await(const {hash} of super.walkTree(commit.body.tree, true)){
-          if(await this.addToMap(hash, localObjects)) break;
+          await this.addToMap(hash, localObjects);
         }
       }
 


### PR DESCRIPTION
After making a test repo of a bunch of copied and pasted files, then trying to modify one and push using es-git I get a `0055fatal: did not receive expected object 20076e54bbad301d4f0ac236bd594ee0cf37331f`

https://github.com/es-git/es-git/blob/6cfa07a51e9f625935500c0e99693fab0ce46446/packages/push-mixin/ts/index.ts#L39


Also thanks for such a great library!