### PR TITLE
Bring your own filesystem?

### DIFF
--- a/packages/byo-fs-repo/.gitignore
+++ b/packages/byo-fs-repo/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+js
+es

--- a/packages/byo-fs-repo/.npmignore
+++ b/packages/byo-fs-repo/.npmignore
@@ -1,0 +1,3 @@
+.*
+*.test.js
+*.test.ts

--- a/packages/byo-fs-repo/package.json
+++ b/packages/byo-fs-repo/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@es-git/byo-fs-repo",
+  "version": "0.1.0",
+  "description": "",
+  "main": "js/index.js",
+  "types": "es/index.d.ts",
+  "module": "es/index.js",
+  "scripts": {
+    "clean": "rm -rf ./es ./js",
+    "tsc": "../../node_modules/.bin/tsc",
+    "babel": "../../node_modules/.bin/babel --source-maps -d js es",
+    "compile": "npm run tsc && npm run babel",
+    "test": "../../node_modules/.bin/ava",
+    "watch+test": "../../node_modules/.bin/tsc -w & ../../node_modules/.bin/ava -w",
+    "watch": "../../node_modules/.bin/tsc -w & ../../node_modules/.bin/babel --source-maps -w -d js es",
+    "prepublishOnly": "npm run clean && npm run compile && npm test"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "ava": {
+    "files": [
+      "es/*.test.js"
+    ],
+    "source": [
+      "es/*.js"
+    ],
+    "require": [
+      "babel-register"
+    ],
+    "babel": {
+      "extends": "../../.babelrc"
+    }
+  },
+  "peerDependencies": {
+    "babel-runtime": "^6.22.0"
+  },
+  "dependencies": {
+    "@es-git/core": "^0.5.0"
+  }
+}

--- a/packages/byo-fs-repo/readme.md
+++ b/packages/byo-fs-repo/readme.md
@@ -1,0 +1,45 @@
+# byo-fs-repo
+
+This is part of the [ES-Git](https://github.com/es-git/es-git) project.
+
+## Install
+
+```bash
+npm install --save @es-git/byo-fs-repo
+```
+
+## Usage
+
+This is an implementation of [`IRawRepo`](https://github.com/es-git/es-git/packages/core#IRawRepo) that uses the supplied implementation of [`IRepoFileSystem`](https://github.com/es-git/es-git/packages/byo-fs-repo#IRepoFileSystem) file system for storage. If you are using this on the server then [`node-fs-repo`](https://github.com/es-git/es-git/packages/node-fs-repo) is easier (it supplies this repo with the Node fs).
+
+```ts
+import Repo from '@es-git/byo-fs-repo';
+
+const repo = new Repo(fs, __dirname + '/.git');
+
+await repo.init();
+```
+
+#### `constructor(fs : IRepoFileSystem, path : string)`
+
+Creates the repository instance. The fs parameter is the file system to use for storage and the path parameter points to a location in the filesystem where either a repo already exists or a new one should be made.
+
+#### `init() : Promise<void>`
+
+Initialize a new empty repository at the path provided in the constructor.
+
+### IRepoFileSystem
+
+This interface describes the actions taken by the repo on the underlying file system.
+
+```ts
+export interface IRepoFileSystem {
+  writeFile(path : string, contents : any): Promise<any>
+  readFile(path : string, encoding? : any): Promise<any>
+  exists(path : string): Promise<any>
+  readDir(path : string): Promise<any>
+  unlink(path : string): Promise<any>
+  stat(path : string): Promise<any>
+  mkdir(path : string): Promise<any>
+}
+```

--- a/packages/byo-fs-repo/ts/index.test.ts
+++ b/packages/byo-fs-repo/ts/index.test.ts
@@ -1,0 +1,7 @@
+import test from 'ava';
+
+import index from './index';
+
+test('blob is blob', t => {
+  t.is(typeof index, 'function');
+})

--- a/packages/byo-fs-repo/ts/index.ts
+++ b/packages/byo-fs-repo/ts/index.ts
@@ -1,0 +1,140 @@
+import { promisify } from 'util';
+import * as fsCallback from 'fs';
+import { join, dirname } from 'path';
+import { IRawRepo, Type, Hash } from '@es-git/core';
+
+export interface IRepoFileSystem {
+  writeFile(path : string, contents : any): Promise<any>
+  readFile(path : string, encoding? : any): Promise<any>
+  exists(path : string): Promise<any>
+  readDir(path : string): Promise<any>
+  unlink(path : string): Promise<any>
+  stat(path : string): Promise<any>
+  mkdir(path : string): Promise<any>
+}
+
+export default class ByoFsRepo implements IRawRepo {
+  readonly fs: IRepoFileSystem
+  readonly path: string
+  constructor(fs: IRepoFileSystem, path : string) {
+    this.fs = fs;
+    this.path = path;
+  }
+
+  async init(){
+    await this.mkdirp(join(this.path, 'branches'));
+    await this.mkdirp(join(this.path, 'info'));
+    await this.mkdirp(join(this.path, 'objects'));
+    await this.mkdirp(join(this.path, 'refs'));
+  }
+
+  async saveRaw(hash : Hash, raw : Uint8Array) : Promise<void> {
+    const path = join(this.path, ...objectsPath(hash));
+    try{
+      await this.fs.writeFile(path, raw).catch(noAccess);
+    }catch(e){
+      await this.mkdirp(dirname(path));
+      await this.fs.writeFile(path, raw).catch(noAccess);
+    }
+  }
+
+  async loadRaw(hash : string) : Promise<Uint8Array | undefined> {
+    return await this.fs.readFile(join(this.path, ...objectsPath(hash))).catch(notExists);
+  }
+
+  async listRefs() : Promise<Hash[]> {
+    const queue = ['refs'];
+    const refs = [];
+    for(const path of queue){
+      const absolutePath = join(this.path, path);
+      const stat = await this.fs.stat(absolutePath);
+      if(stat.isDirectory()){
+        const files : string[] = await this.fs.readDir(absolutePath);
+        queue.push(...files.map(file => join(path, file)));
+      }else{
+        refs.push(path);
+      }
+    }
+    return refs;
+  }
+
+  async getRef(ref : string) : Promise<string | undefined> {
+    const result : string | undefined = await this.fs.readFile(join(this.path, ref), 'utf8').catch(notExists);
+    if(result) return result.trim();
+  }
+
+  async setRef(ref : string, hash : string | undefined) : Promise<void> {
+    const path = join(this.path, ref);
+    if(hash === undefined){
+      await this.fs.unlink(join(this.path, ref)).catch(notExists);
+    }else{
+      try{
+        await this.fs.writeFile(path, `${hash}\n`);
+      }catch(e){
+        await this.mkdirp(dirname(path));
+        await this.fs.writeFile(path, `${hash}\n`);
+      }
+    }
+  }
+
+  async hasObject(hash: string): Promise<boolean> {
+    const stat = await this.fs.stat(join(this.path, ...objectsPath(hash)));
+    return stat.isFile();
+  }
+
+  async saveMetadata(name: string, value: Uint8Array | undefined): Promise<void> {
+    const path = join(this.path, name);
+    if(value){
+      try{
+        await this.fs.writeFile(path, value);
+      }catch(e){
+        await this.mkdirp(dirname(path));
+        await this.fs.writeFile(path, value);
+      }
+    }else{
+      await this.fs.unlink(path).catch(notExists);
+    }
+  }
+
+  async loadMetadata(name: string): Promise<Uint8Array | undefined> {
+    return await this.fs.readFile(join(this.path, name)).catch(notExists);
+  }
+
+  private async mkdirp(p : string) {
+    try{
+      await this.fs.mkdir(p);
+    }catch(er){
+      if(er.code === 'ENOENT'){
+        await this.mkdirp(dirname(p));
+        await this.fs.mkdir(p);
+      }else{
+        const stat = await this.fs.stat(p);
+        if (!stat.isDirectory()) throw er;
+      }
+    }
+  }
+}
+
+function objectsPath(hash : Hash){
+  return [
+    'objects',
+    hash.substr(0, 2),
+    hash.substr(2)
+  ];
+}
+
+function notExists(e : any){
+  if(e.code === 'ENOENT'){
+    return undefined;
+  }else{
+    throw e;
+  }
+}
+
+function noAccess(e : any){
+  if(e.code === 'EACCES'){
+    return;
+  }else{
+    throw e;
+  }
+}

--- a/packages/byo-fs-repo/tsconfig.json
+++ b/packages/byo-fs-repo/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "outDir": "./es"
+  },
+  "include": [
+    "./ts/**/*.ts"
+  ],
+  "extends": "../../tsconfig.json"
+}

--- a/packages/node-fs-repo/package.json
+++ b/packages/node-fs-repo/package.json
@@ -39,6 +39,6 @@
     "babel-runtime": "^6.22.0"
   },
   "dependencies": {
-    "@es-git/core": "^0.5.0"
+    "@es-git/byo-fs-repo": "^0.1.0"
   }
 }

--- a/packages/node-fs-repo/ts/index.ts
+++ b/packages/node-fs-repo/ts/index.ts
@@ -1,7 +1,6 @@
 import { promisify } from 'util';
 import * as fsCallback from 'fs';
-import { join, dirname } from 'path';
-import { IRawRepo, Type, Hash } from '@es-git/core';
+import ByoFsRepo from '@es-git/byo-fs-repo';
 
 const fs = {
   writeFile: promisify(fsCallback.writeFile),
@@ -13,126 +12,8 @@ const fs = {
   mkdir: promisify(fsCallback.mkdir)
 }
 
-export default class NodeFsRepo implements IRawRepo {
-  readonly path: string
+export default class NodeFsRepo extends ByoFsRepo {
   constructor(path : string) {
-    this.path = path;
-  }
-
-  async init(){
-    await mkdirp(join(this.path, 'branches'));
-    await mkdirp(join(this.path, 'info'));
-    await mkdirp(join(this.path, 'objects'));
-    await mkdirp(join(this.path, 'refs'));
-  }
-
-  async saveRaw(hash : Hash, raw : Uint8Array) : Promise<void> {
-    const path = join(this.path, ...objectsPath(hash));
-    try{
-      await fs.writeFile(path, raw).catch(noAccess);
-    }catch(e){
-      await mkdirp(dirname(path));
-      await fs.writeFile(path, raw).catch(noAccess);
-    }
-  }
-
-  async loadRaw(hash : string) : Promise<Uint8Array | undefined> {
-    return await fs.readFile(join(this.path, ...objectsPath(hash))).catch(notExists);
-  }
-
-  async listRefs() : Promise<Hash[]> {
-    const queue = ['refs'];
-    const refs = [];
-    for(const path of queue){
-      const absolutePath = join(this.path, path);
-      const stat = await fs.stat(absolutePath);
-      if(stat.isDirectory()){
-        const files : string[] = await fs.readDir(absolutePath);
-        queue.push(...files.map(file => join(path, file)));
-      }else{
-        refs.push(path);
-      }
-    }
-    return refs;
-  }
-
-  async getRef(ref : string) : Promise<string | undefined> {
-    const result : string | undefined = await fs.readFile(join(this.path, ref), 'utf8').catch(notExists);
-    if(result) return result.trim();
-  }
-
-  async setRef(ref : string, hash : string | undefined) : Promise<void> {
-    const path = join(this.path, ref);
-    if(hash === undefined){
-      await fs.unlink(join(this.path, ref)).catch(notExists);
-    }else{
-      try{
-        await fs.writeFile(path, `${hash}\n`);
-      }catch(e){
-        await mkdirp(dirname(path));
-        await fs.writeFile(path, `${hash}\n`);
-      }
-    }
-  }
-
-  async hasObject(hash: string): Promise<boolean> {
-    const stat = await fs.stat(join(this.path, ...objectsPath(hash)));
-    return stat.isFile();
-  }
-
-  async saveMetadata(name: string, value: Uint8Array | undefined): Promise<void> {
-    const path = join(this.path, name);
-    if(value){
-      try{
-        await fs.writeFile(path, value);
-      }catch(e){
-        await mkdirp(dirname(path));
-        await fs.writeFile(path, value);
-      }
-    }else{
-      await fs.unlink(path).catch(notExists);
-    }
-  }
-
-  async loadMetadata(name: string): Promise<Uint8Array | undefined> {
-    return await fs.readFile(join(this.path, name)).catch(notExists);
-  }
-}
-
-function objectsPath(hash : Hash){
-  return [
-    'objects',
-    hash.substr(0, 2),
-    hash.substr(2)
-  ];
-}
-
-function notExists(e : any){
-  if(e.code === 'ENOENT'){
-    return undefined;
-  }else{
-    throw e;
-  }
-}
-
-function noAccess(e : any){
-  if(e.code === 'EACCES'){
-    return;
-  }else{
-    throw e;
-  }
-}
-
-async function mkdirp(p : string) {
-  try{
-    await fs.mkdir(p);
-  }catch(er){
-    if(er.code === 'ENOENT'){
-      await mkdirp(dirname(p));
-      await fs.mkdir(p);
-    }else{
-      const stat = await fs.stat(p);
-      if (!stat.isDirectory()) throw er;
-    }
+    super(fs, path);
   }
 }


### PR DESCRIPTION
*Thank you all for your great work on `js-git` and now `es-git`.  This is a feature proposal.*

`node-fs-repo` depends on the global node `fs`, and so is tricky to run in a browser.  `byo-fs-repo` is my attempt at extracting out the real `fs` interactions so that it's easy to supply non-node filesystem implementations (in the browser).

The particular filesystem I have in mind is the lightweight Dropbox wrapper, [`dropbox-fs`](https://github.com/sallar/dropbox-fs) (or a promisified version of that anyway).

PS. I'm a total noob to Typescript so I'm sure what I've done is ugly.  Consider this more like supporting material to make discussion of the proposed feature clearer!

PPS. Also, I didn't do more than make `IRepoFileSystem` pass the typescript compilation stage, having `any` scattered around there is obviously weak sauce, that's obviously something to improve if this proposal is of interest to you.